### PR TITLE
🔧 Fix Docker build error by removing invalid child_process dependency

### DIFF
--- a/proxy/package.json
+++ b/proxy/package.json
@@ -10,8 +10,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
-    "body-parser": "^1.20.2",
-    "child_process": "^1.0.2"
+    "body-parser": "^1.20.2"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"


### PR DESCRIPTION
## 🔧 Fix Docker Build Issue

This PR fixes the Docker build error that occurs when running `docker-compose up`.

### 🐛 Problem
The `npm ci --only=production` command was failing during Docker build because `child_process` was incorrectly listed as a dependency in `package.json`.

### ✅ Solution
- **Removed `child_process` from dependencies** - `child_process` is a built-in Node.js module and doesn't need to be installed
- **Kept only actual npm packages** - express, cors, body-parser

### 🧪 Testing
This fix resolves the Docker build error:
```
npm error A complete log of this run can be found in: /root/.npm/_logs/2025-06-01T06_31_22_533Z-debug-0.log
failed to solve: process "/bin/sh -c npm ci --only=production" did not complete successfully: exit code 1
```

After this fix, `docker-compose up` should work correctly.

### 📝 Changes
- Updated `proxy/package.json` to remove the invalid `child_process` dependency
- All functionality remains the same since `child_process` is always available as a core Node.js module